### PR TITLE
feat: Adjust grid column count and visibility logic for profile tabs

### DIFF
--- a/src/app/(root)/profile/components/ProfileTabs/ProfileTabs.tsx
+++ b/src/app/(root)/profile/components/ProfileTabs/ProfileTabs.tsx
@@ -5,11 +5,12 @@ import profiletabStyles from "./profileTabs.module.css"
 import Link from "next/link";
 import { useSelector } from "react-redux";
 import Loading from "@/components/common/Loading";
-import { usePathname } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 
 const ProfileTabs = () => {
     const pathname = usePathname();
     const { user } = useSelector((state: IRootState) => state.userSlice);
+    const { id: paramsId } = useParams();
 
     if (!user) {
         return <Loading />
@@ -22,39 +23,34 @@ const ProfileTabs = () => {
             title: "Posts",
             path: `/profile/${_id}/posts`,
         },
-        // {
-        //     title: 'Questions',
-        //     path: `/profile/${_id}/questions`,
-        //     // path: "/questions",
-        // },
         {
             title: 'Jobs',
             path: "#",
-            // path: "/courses",
+            // path: "/profile/${_id}/courses",
         },
 
         {
             title: 'Books',
             path: "#",
-            // path: "/books",
+            // path: "/profile/${_id}/books",
         },
         {
             title: 'Courses',
             path: "#",
-            // path: "/meetup",
+            // path: "/profile/${_id}/courses",
         },
         {
             title: 'Saved',
             path: "#",
-            // path: "/courses",
+            // path: "/profile/${_id}/saved",
         },
     ]
 
     return (
-        <div className={`mt-3 lg:my-5 grid md:grid-cols-5  justify-center gap-3 lg:gap-7 ${profiletabStyles.tabLink}`}>
+        <div className={`mt-3 lg:my-5 grid ${paramsId !== _id ? 'md:grid-cols-4' : 'md:grid-cols-5'}  justify-center gap-3 lg:gap-7 ${profiletabStyles.tabLink}`}>
             {
                 profileTabLinks.map((link, i) =>
-                    <Link className={`${link.path === pathname ? 'bg-secondary text-white' : 'text-black-secondary'}`} key={i} href={link.path}>{link.title}</Link>
+                    <Link className={`${(paramsId !== _id && link.title === 'Saved') ? 'hidden' : 'block'} ${link.path === pathname ? 'bg-secondary text-white' : 'text-black-secondary'}`} key={i} href={link.path}>{link.title}</Link>
                 )
             }
         </div>

--- a/src/components/Posts/PostCard.tsx
+++ b/src/components/Posts/PostCard.tsx
@@ -33,10 +33,12 @@ const PostCard = ({ post }: any) => {
                 <div className='flex gap-x-3 items-center'>
 
                     {/* User Image */}
-                    <UserImage
-                        customWidth="w-16"
-                        profilePicture={profilePicture}
-                    />
+                    <Link href={`/profile/${_id}/posts`}>
+                        <UserImage
+                            customWidth="w-16"
+                            profilePicture={profilePicture}
+                        />
+                    </Link>
 
                     {/* Title and Category Wrapper */}
                     <div>


### PR DESCRIPTION
- Modify the grid column count based on whether the current user's ID matches the profile ID, changing from 4 to 5 columns for the current user's profile.
- Update the visibility logic for the 'Saved' tab, ensuring it remains hidden for users other than the profile owner.